### PR TITLE
Show train delay instead of route numbers

### DIFF
--- a/railNetwork.ts
+++ b/railNetwork.ts
@@ -266,11 +266,10 @@ export class RailNetwork {
         // Now use only the most recent trip update for each trip_id
         // After deduplication
         const now = Math.floor(Date.now() / 1000); // current time in seconds
-
         const dedupedTripUpdates = Array.from(vehicleUpdateMap.values())
             .filter(entity => {
                 const ts = entity.trip_update?.timestamp ?? 0;
-                return (now - ts) <= 180; // Only include updates from the last 3 minutes
+                return (now - ts) <= 300; // Only include updates from the last 5 minutes
             });
 
         if (dedupedTripUpdates) {

--- a/railNetwork.ts
+++ b/railNetwork.ts
@@ -228,6 +228,7 @@ export class RailNetwork {
         this.trackedTrains = updateTrackedTrains(this.trackBlocks, this.trackedTrains, this.trainEntities, this.config.LEDRailsAPI.displayThreshold, this.invisibleTrains, this.id);
 
         // After fetching fresh data, extract delays from tripupdates and update tracked trains
+
         const freshTripUpdates = freshData?.entity?.filter(e => {
             if (!e.trip_update) return false; // only want trip updates
 
@@ -244,8 +245,38 @@ export class RailNetwork {
             return false;
         });
 
-        if (freshTripUpdates) {
-            for (const entity of freshTripUpdates) {
+        // After filtering freshTripUpdates
+        const vehicleUpdateMap = new Map<string, Entity>();
+
+
+        for (const entity of freshTripUpdates) {
+            const vehicleId = entity.trip_update?.vehicle?.id;
+            if (!vehicleId) continue;
+
+            // If this vehicleId is not in the map, or this entity is newer, replace it
+            const existing = vehicleUpdateMap.get(vehicleId);
+            const newTimestamp = entity.trip_update?.timestamp ?? 0;
+            const existingTimestamp = existing?.trip_update?.timestamp ?? 0;
+
+            if (!existing || newTimestamp > existingTimestamp) {
+                vehicleUpdateMap.set(vehicleId, entity);
+            }
+}
+
+        // Now use only the most recent trip update for each trip_id
+        // After deduplication
+        const now = Math.floor(Date.now() / 1000); // current time in seconds
+
+        const dedupedTripUpdates = Array.from(vehicleUpdateMap.values())
+            .filter(entity => {
+                const ts = entity.trip_update?.timestamp ?? 0;
+                return (now - ts) <= 180; // Only include updates from the last 3 minutes
+            });
+
+        if (dedupedTripUpdates) {
+            log(LOG_LABELS.SYSTEM, `Processing ${dedupedTripUpdates.length} trip updates for delays`);
+            var onTimeCount = 0;
+            for (const entity of dedupedTripUpdates) {
                 const tripUpdate = entity.trip_update;
                 
                 // Add debug logging
@@ -253,7 +284,7 @@ export class RailNetwork {
                 
                 if (tripUpdate?.stop_time_update == null) {
                     log(LOG_LABELS.SYSTEM, `Skipping a trip update with no stop_time_update`);
-                    continue;   
+                    continue;
                 }
 
                 // Split this into separate lines for debugging
@@ -270,6 +301,7 @@ export class RailNetwork {
                 }
 
                 const vehicleId = tripUpdate.vehicle?.id;
+                const vehicleLabel = tripUpdate.vehicle?.label;
                 if (!vehicleId) {
                     // log(LOG_LABELS.SYSTEM, `Skip update: no vehicle id on incoming entity`);
                     continue;
@@ -280,16 +312,26 @@ export class RailNetwork {
                 if (trackedTrain) {
                     trackedTrain.delaySeconds = delay;
                     trackedTrain.delayStatus = this.getDelayColor(delay);
-                    // log(LOG_LABELS.SYSTEM, `Updated tracked train ${vehicleId} with delay status: ${trackedTrain.delayStatus}`);
+                    if (trackedTrain.delayStatus !== 'ON_TIME') {
+                        const minutes = Math.floor(Math.abs(delay) / 60);
+                        const seconds = Math.abs(delay) % 60;
+                        const sign = delay < 0 ? '-' : '+';
+                        log(LOG_LABELS.SYSTEM, `${tripUpdate.trip.trip_id} ${vehicleLabel}\tdelay ${sign} ${minutes}:${seconds}\t${trackedTrain.delayStatus}`);
+                    } else {
+                        // increment the on-time log count
+                        onTimeCount++;
+                    }
                 } else {
-                    log(LOG_LABELS.SYSTEM, `No tracked train for vehicle ${vehicleId}`);
+                    //log(LOG_LABELS.SYSTEM, `No tracked train for vehicle ${vehicleId}`);
                 }
             }
+            const percentage = Math.round((onTimeCount / dedupedTripUpdates.length) * 100);
+            log(LOG_LABELS.SYSTEM, `Total on-time trains: ${onTimeCount} of ${dedupedTripUpdates.length} (${percentage}%)`);
         }
     }
 
     getDelayColor(delay?: number): string {
-        var delayState = 'ON_TIME';
+        var delayState = 'ON_TIME'; // On-Time until proven otherwise
         if (!delay) return delayState;
         
         const thresholds = this.config.LEDRailsAPI.delayThresholds;

--- a/railNetwork.ts
+++ b/railNetwork.ts
@@ -227,10 +227,22 @@ export class RailNetwork {
 
         this.trackedTrains = updateTrackedTrains(this.trackBlocks, this.trackedTrains, this.trainEntities, this.config.LEDRailsAPI.displayThreshold, this.invisibleTrains, this.id);
 
-        // After fetching fresh data, extract delays
-        const entitiesById = new Map(this.entities.map(e => [e.vehicle?.vehicle?.id, e]));
-        const freshTripUpdates = freshData?.entity?.filter(e => e.trip_update);
-        //log(LOG_LABELS.SYSTEM, `Trip Updates: ${JSON.stringify(freshTripUpdates, null, 2)}`);
+        // After fetching fresh data, extract delays from tripupdates and update tracked trains
+        const freshTripUpdates = freshData?.entity?.filter(e => {
+            if (!e.trip_update) return false; // only want trip updates
+
+            if (this.config.trainFilter.entityID) { // filter by entity ID range (only want trains)
+                const idNum = Number(e.trip_update.vehicle?.id);
+                if (!idNum) return false;
+                return idNum >= this.config.trainFilter.entityID.start && 
+                       idNum <= this.config.trainFilter.entityID.end;
+            } else if (this.config.trainFilter.trip_ID) { // filter by trip_id substring
+                const includesStr = this.config.trainFilter.trip_ID?.includes;
+                return includesStr !== undefined && 
+                       e.trip_update.trip?.trip_id?.includes(includesStr);
+            }
+            return false;
+        });
 
         if (freshTripUpdates) {
             for (const entity of freshTripUpdates) {

--- a/railNetwork.ts
+++ b/railNetwork.ts
@@ -232,7 +232,7 @@ export class RailNetwork {
         const freshTripUpdates = freshData?.entity?.filter(e => e.trip_update);
         //log(LOG_LABELS.SYSTEM, `Trip Updates: ${JSON.stringify(freshTripUpdates, null, 2)}`);
 
-        if (freshData?.entity) {
+        if (freshTripUpdates) {
             for (const entity of freshTripUpdates) {
                 const tripUpdate = entity.trip_update;
                 
@@ -240,7 +240,7 @@ export class RailNetwork {
                 // log(LOG_LABELS.SYSTEM, `Processing trip update: ${JSON.stringify(tripUpdate, null, 2)}`);
                 
                 if (tripUpdate?.stop_time_update == null) {
-                    log(LOG_LABELS.SYSTEM, `Could not retrieve stop_time_update from ${Object.keys(tripUpdate).join(', ')}`);
+                    log(LOG_LABELS.SYSTEM, `Skipping a trip update with no stop_time_update`);
                     continue;   
                 }
 

--- a/railNetwork.ts
+++ b/railNetwork.ts
@@ -15,7 +15,7 @@ import {
 // Import cache helpers, train pairing logic, and logging
 import { saveToCache, readFromCache } from './cache';
 import { TrainPair, checkForTrainPairs } from './trainPairs';
-import { log } from './customUtils';
+import { log, LOG_LABELS } from './customUtils';
 
 /**
  * Configuration for a rail network, loaded from config.json
@@ -58,6 +58,12 @@ interface RailNetworkConfig {
         randomizeTimeOffset?: boolean; // Whether to randomize time offset for display (used for WLG where all trains are updated simultaneously)
         colors: {
             [key: string]: [number, number, number]; // Mapping of route names to [R,G,B] color values
+        };
+        delayThresholds: {
+            early: number; // Delay in seconds for early trains (negative)
+            minor: number; // Delay in seconds for minor delay
+            moderate: number; // Delay in seconds for moderate delay
+            severe: number; // Delay in seconds for severe delay
         };
     };
 }
@@ -126,6 +132,12 @@ export class RailNetwork {
                     colors: IdToColor,
                     updates: [],
                 },
+                delayThresholds: {
+                    early: this.config.LEDRailsAPI.delayThresholds?.early,
+                    minor: this.config.LEDRailsAPI.delayThresholds?.minor,
+                    moderate: this.config.LEDRailsAPI.delayThresholds?.moderate,
+                    severe: this.config.LEDRailsAPI.delayThresholds?.severe
+                }
             });
         }
 
@@ -214,6 +226,68 @@ export class RailNetwork {
         }
 
         this.trackedTrains = updateTrackedTrains(this.trackBlocks, this.trackedTrains, this.trainEntities, this.config.LEDRailsAPI.displayThreshold, this.invisibleTrains, this.id);
+
+        // After fetching fresh data, extract delays
+        const entitiesById = new Map(this.entities.map(e => [e.vehicle?.vehicle?.id, e]));
+        const freshTripUpdates = freshData?.entity?.filter(e => e.trip_update);
+        //log(LOG_LABELS.SYSTEM, `Trip Updates: ${JSON.stringify(freshTripUpdates, null, 2)}`);
+
+        if (freshData?.entity) {
+            for (const entity of freshTripUpdates) {
+                const tripUpdate = entity.trip_update;
+                
+                // Add debug logging
+                // log(LOG_LABELS.SYSTEM, `Processing trip update: ${JSON.stringify(tripUpdate, null, 2)}`);
+                
+                if (tripUpdate?.stop_time_update == null) {
+                    log(LOG_LABELS.SYSTEM, `Could not retrieve stop_time_update from ${Object.keys(tripUpdate).join(', ')}`);
+                    continue;   
+                }
+
+                // Split this into separate lines for debugging
+                const departureDelay = tripUpdate?.stop_time_update?.departure?.delay;
+                const arrivalDelay = tripUpdate?.stop_time_update?.arrival?.delay;
+                // log(LOG_LABELS.SYSTEM, `Departure delay: ${departureDelay},\n\t\t Arrival delay: ${arrivalDelay}`);
+                
+                const delay = arrivalDelay ?? departureDelay; // Treat arrival delay as primary, fallback to departure delay
+
+                // skip if stop_time_update or arrival or delay is null/undefined
+                if (delay == null) {
+                    log(LOG_LABELS.SYSTEM, `Skip Entity, no delay info available: ${JSON.stringify(tripUpdate?.stop_time_update)}`);
+                    continue;
+                }
+
+                const vehicleId = tripUpdate.vehicle?.id;
+                if (!vehicleId) {
+                    // log(LOG_LABELS.SYSTEM, `Skip update: no vehicle id on incoming entity`);
+                    continue;
+                }
+
+                // Update the corresponding tracked train
+                const trackedTrain = this.trackedTrains.find(t => t.trainId === vehicleId);
+                if (trackedTrain) {
+                    trackedTrain.delaySeconds = delay;
+                    trackedTrain.delayStatus = this.getDelayColor(delay);
+                    // log(LOG_LABELS.SYSTEM, `Updated tracked train ${vehicleId} with delay status: ${trackedTrain.delayStatus}`);
+                } else {
+                    log(LOG_LABELS.SYSTEM, `No tracked train for vehicle ${vehicleId}`);
+                }
+            }
+        }
+    }
+
+    getDelayColor(delay?: number): string {
+        var delayState = 'ON_TIME';
+        if (!delay) return delayState;
+        
+        const thresholds = this.config.LEDRailsAPI.delayThresholds;
+        if (delay <= thresholds.early) delayState = 'EARLY';
+        if (delay >= thresholds.minor) delayState = 'DELAY_MINOR';
+        if (delay >= thresholds.moderate) delayState = 'DELAY_MODERATE';
+        if (delay >= thresholds.severe) delayState = 'DELAY_SEVERE';
+        // log(LOG_LABELS.SYSTEM, `Determined delay status: ${delayState} (${delay}s)`);
+        
+        return delayState;
     }
 
     /**
@@ -226,7 +300,7 @@ export class RailNetwork {
     async updateLEDRailsAPIs() {
         for (let index = 0; index < this.ledRailsAPIs.length; index++) {
             const api = this.ledRailsAPIs[index];
-            if (api) {
+            if (api) {                
                 this.ledRailsAPIs[index] = generateLedMap(api, this.trackedTrains, this.invisibleTrains);
             }
         }

--- a/railNetworks/AKL/config.json
+++ b/railNetworks/AKL/config.json
@@ -33,10 +33,21 @@
     "displayThreshold": 900,
     "colors": {
       "OUT-OF-SERVICE": [223, 0, 223],
-      "WEST-201": [0, 255, 0],
-      "EAST-201": [255, 128, 0],
-      "ONE-201": [0, 255, 255],
-      "STH-201": [255, 0, 0]
+      "WEST-201": [0, 255, 43],
+      "EAST-201": [235, 162, 34],
+      "ONE-201": [0, 134, 255],
+      "STH-201": [255, 0, 0],
+      "DELAY_SEVERE": [220, 0, 100],
+      "DELAY_MODERATE": [255, 0, 0],
+      "DELAY_MINOR": [255, 140, 0],
+      "ON_TIME": [0, 200, 0],
+      "EARLY": [0, 180, 180]
+    },
+    "delayThresholds": {
+      "early": -30,
+      "minor": 90,
+      "moderate": 600,
+      "severe": 1200
     }
   }
 }

--- a/trackBlocks.ts
+++ b/trackBlocks.ts
@@ -15,6 +15,12 @@ export interface LEDRailsAPI {
     randomizeTimeOffset: boolean; // Whether to randomize time offsets for LED updates
     updateInterval: number; // Interval in seconds between updates
     output: LEDRailsAPIOutput; // The prepared output to send to the LED Rails API
+    delayThresholds: {
+        early: number; // Delay in seconds for early trains (negative)
+        minor: number; // Delay in seconds for minor delay
+        moderate: number; // Delay in seconds for moderate delay
+        severe: number; // Delay in seconds for severe delay
+    };
 }
 
 interface LEDRailsAPIOutput {
@@ -48,6 +54,8 @@ export interface TrainInfo {
     currentBlock: number | undefined; // Track block number (e.g., 301)
     previousBlock: number | undefined; // Previous block number (e.g., 300)
     route: string; // Route ID from GTFS e.g. "EAST-201"
+    delaySeconds: number; // Delay in seconds (negative if early)
+    delayStatus: string; // Categorised delay string e.g. "ON_TIME", "DELAY_MINOR"
     tripId: string | undefined; // Trip ID from GTFS
 }
 
@@ -318,8 +326,11 @@ function addNewTrain(trackedTrains: TrainInfo[], gtfsTrain: Entity): void {
             speed: position?.speed, // Can be undefined (e.g. WLG does not provide speed)
         },
         route: String(vehicle?.trip?.route_id ?? 'OUT-OF-SERVICE'),
+        delaySeconds: 0, // default to 0
+        delayStatus: 'DELAY_MINOR', // default to DELAY_MINOR until proven otherwise
         currentBlock: undefined,
         previousBlock: undefined,
+        tripId: vehicle?.trip?.trip_id
     });
 }
 
@@ -464,7 +475,9 @@ export function generateLedMap(api: LEDRailsAPI, trackedTrains: TrainInfo[], inv
         .forEach(train => {
             // Only update if both current and previous block are known
             if (train.currentBlock !== undefined && train.previousBlock !== undefined) {
-                const colorId = api.routeToColorId[train.route]; // Get color for this route
+                // const colorId = api.routeToColorId[train.route]; // Get color for this route
+                const colorId = api.routeToColorId[train.delayStatus]; // Get color for this level of delay
+                //log(LOG_LABELS.SYSTEM, `Train ${train.trainId} on route ${train.route} has delay status ${train.delayStatus} with color ID ${colorId}`);
                 if (colorId != undefined) {
                     let timeOffset = 0;
                     // Determine time offset for LED animation
@@ -485,7 +498,8 @@ export function generateLedMap(api: LEDRailsAPI, trackedTrains: TrainInfo[], inv
                         t: timeOffset, // Time offset for animation
                     });
                 } else {
-                    log(LOG_LABELS.ERROR, `No color mapping for route ${train.route}`);
+                    // log(LOG_LABELS.ERROR, `No color mapping for route ${train.route}`);
+                    log(LOG_LABELS.ERROR, `No color mapping for delay status ${train.delayStatus}`);
                 }
             }
         });

--- a/trackBlocks.ts
+++ b/trackBlocks.ts
@@ -471,6 +471,7 @@ export function generateLedMap(api: LEDRailsAPI, trackedTrains: TrainInfo[], inv
     // Iterate over trains that should be displayed
     trackedTrains
         .filter(train => train.position.timestamp >= displayCutoff) // Only show trains with recent updates
+        .filter(train => train.route !== 'OUT-OF-SERVICE') // Exclude out-of-service trains
         .filter(train => !invisibleTrainIds.includes(train.trainId)) // Exclude invisible trains (e.g. paired trains)
         .forEach(train => {
             // Only update if both current and previous block are known


### PR DESCRIPTION
This PR changes the backend to serve colours based on the delay of a trip, rather than the route number.